### PR TITLE
Lower MSRV to 1.56, when edition2021 was added

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,7 +183,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: hack
-          args: --version-range 1.59.. check --lib --all-features
+          args: --version-range 1.56.. check --lib --all-features
 
   minver:
     name: Check minimal versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ name = "tracing-filter"
 version = "0.1.0-dev.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-rust-version = "1.59"
+rust-version = "1.56"
 
 description = "experimental next-generation filtering support for tracing"
 

--- a/src/bin/legacy.rs
+++ b/src/bin/legacy.rs
@@ -11,8 +11,8 @@ fn main() {
 fn show_directive(spec: String) {
     let (filter, report) = Filter::parse(spec);
 
-    println!("\nFilter normalizes as:\n{filter}\n");
+    println!("\nFilter normalizes as:\n{}\n", filter);
     if let Some(report) = report {
-        println!("Error: {report:?}");
+        println!("Error: {:?}", report);
     }
 }

--- a/src/bin/simple.rs
+++ b/src/bin/simple.rs
@@ -14,10 +14,10 @@ fn show_directive(spec: String) {
     println!();
 
     if let Some(filter) = filter {
-        println!("Filter normalizes as:\n{filter}\n");
+        println!("Filter normalizes as:\n{}\n", filter);
     }
 
     if let Some(report) = report {
-        println!("Error: {report:?}");
+        println!("Error: {:?}", report);
     }
 }

--- a/src/legacy/mod.rs
+++ b/src/legacy/mod.rs
@@ -187,7 +187,7 @@ impl fmt::Display for Filter {
             if wrote_any {
                 write!(f, ",")?;
             }
-            write!(f, "{directive}")?;
+            write!(f, "{}", directive)?;
             wrote_any = true;
         }
 
@@ -195,7 +195,7 @@ impl fmt::Display for Filter {
             if wrote_any {
                 write!(f, ",")?;
             }
-            write!(f, "{directive}")?;
+            write!(f, "{}", directive)?;
             wrote_any = true;
         }
 

--- a/src/legacy/parse.rs
+++ b/src/legacy/parse.rs
@@ -81,7 +81,7 @@ impl Filter {
                     target: directive
                         .target
                         .as_deref()
-                        .map(|t| format!("the `{t}` target"))
+                        .map(|t| format!("the `{}` target", t))
                         .unwrap_or_else(|| "all targets".into()),
                 });
             }
@@ -379,7 +379,11 @@ struct DisabledDirective {
 #[derive(Debug, Error, Diagnostic)]
 #[diagnostic(
     severity(advice),
-    help("to enable {}logging, remove the `{}` feature", .earlier_level.map(|l| format!("{l} ")).unwrap_or_default(), .feature)
+    help(
+        "to enable {}logging, remove the `{}` feature",
+        .earlier_level.map(|l| format!("{} ", l)).unwrap_or_default(),
+        .feature
+    ),
 )]
 #[error("the static max level is `{}`", .static_level)]
 struct StaticMaxAdvice {

--- a/src/simple/mod.rs
+++ b/src/simple/mod.rs
@@ -43,7 +43,7 @@ impl fmt::Display for Filter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for directive in &*self.directives {
             if let Some(target) = &directive.target {
-                write!(f, "{target}=")?;
+                write!(f, "{}=", target)?;
             }
             write!(f, "{},", directive.level)?;
         }


### PR DESCRIPTION
This makes us compliant with tokio-rs's msrv policy