### PR TITLE
Update compact_str to v0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "experimental next-generation filtering support for tracing"
 autotests = false
 
 [dependencies]
-compact_str = "0.3.2"
+compact_str = "0.4"
 matchers = "0.1.0"
 miette = { version = "4.7.1", features = ["fancy"] }
 once_cell = "1.12.0"

--- a/src/legacy/directive.rs
+++ b/src/legacy/directive.rs
@@ -1,7 +1,7 @@
 use {
     super::matcher::{CallsiteMatch, CallsiteMatcher, FieldMatch, Match},
     crate::SmallVec,
-    compact_str::CompactStr,
+    compact_str::CompactString,
     std::{cmp::Ordering, collections::HashMap, fmt},
     tracing_core::{LevelFilter, Metadata},
 };
@@ -16,9 +16,9 @@ pub(super) type Dynamics = DirectiveSet<DynamicDirective>;
 
 #[derive(Debug, PartialEq, Eq)]
 pub(super) struct DynamicDirective {
-    pub(super) span: Option<CompactStr>,
+    pub(super) span: Option<CompactString>,
     pub(super) fields: SmallVec<FieldMatch>,
-    pub(super) target: Option<CompactStr>,
+    pub(super) target: Option<CompactString>,
     pub(super) level: LevelFilter,
 }
 
@@ -26,8 +26,8 @@ pub(super) type Statics = DirectiveSet<StaticDirective>;
 
 #[derive(Debug, PartialEq, Eq)]
 pub(super) struct StaticDirective {
-    pub(super) target: Option<CompactStr>,
-    pub(super) fields: SmallVec<CompactStr>,
+    pub(super) target: Option<CompactString>,
+    pub(super) fields: SmallVec<CompactString>,
     pub(super) level: LevelFilter,
 }
 
@@ -289,8 +289,8 @@ impl Ord for DynamicDirective {
         let ordering = self
             .target
             .as_ref()
-            .map(CompactStr::len)
-            .cmp(&other.target.as_ref().map(CompactStr::len))
+            .map(CompactString::len)
+            .cmp(&other.target.as_ref().map(CompactString::len))
             // Next compare based on the presence of span names.
             .then_with(|| self.span.is_some().cmp(&other.span.is_some()))
             // Then we compare how many fields are defined by each
@@ -347,8 +347,8 @@ impl Ord for StaticDirective {
         let ordering = self
             .target
             .as_ref()
-            .map(CompactStr::len)
-            .cmp(&other.target.as_ref().map(CompactStr::len))
+            .map(CompactString::len)
+            .cmp(&other.target.as_ref().map(CompactString::len))
             // Then we compare how many field names are matched by each directive.
             .then_with(|| self.fields.len().cmp(&other.fields.len()))
             // Finally, we fall back to lexicographical ordering if the directives are

--- a/src/legacy/matcher.rs
+++ b/src/legacy/matcher.rs
@@ -1,6 +1,6 @@
 use {
     crate::SmallVec,
-    compact_str::CompactStr,
+    compact_str::CompactString,
     matchers::Pattern,
     std::{
         cmp::Ordering,
@@ -19,7 +19,7 @@ pub(super) struct MatchSet<T> {
 
 #[derive(Debug, PartialEq, Eq)]
 pub(super) struct FieldMatch {
-    pub(super) name: CompactStr,
+    pub(super) name: CompactString,
     pub(super) value: Option<ValueMatch>,
 }
 
@@ -53,7 +53,7 @@ pub(super) enum ValueMatch {
 #[derive(Debug, Clone)]
 pub(super) struct PatternMatch {
     pub(super) matcher: Pattern,
-    pub(super) pattern: CompactStr,
+    pub(super) pattern: CompactString,
 }
 
 pub(super) trait Match {

--- a/src/simple/mod.rs
+++ b/src/simple/mod.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{Diagnostics, DEFAULT_ENV},
-    compact_str::CompactStr,
+    compact_str::CompactString,
     std::{borrow::Cow, cmp, env, ffi::OsStr, fmt},
     tracing_core::{Interest, LevelFilter, Metadata},
     tracing_subscriber::layer::Context,
@@ -47,7 +47,7 @@ pub struct Filter {
 
 #[derive(Debug, PartialEq, Eq)]
 struct Directive {
-    target: Option<CompactStr>,
+    target: Option<CompactString>,
     level: LevelFilter,
 }
 


### PR DESCRIPTION
**Context**
In the most recent version of [`compact_str`](https://github.com/ParkMyCar/compact_str), we renamed `CompactStr` to `CompactString`. You can continue to use `CompactStr` but there is a deprecation warning on it.

**Changes**
This PR updates `compact_str` to `v0.4`, renaming uses of `CompactStr` to `CompactString` to prevent the warning